### PR TITLE
calls the singular recalculateSolution to only regrade this one users…

### DIFF
--- a/Modules/Test/classes/class.ilTestScoringGUI.php
+++ b/Modules/Test/classes/class.ilTestScoringGUI.php
@@ -365,7 +365,7 @@ class ilTestScoringGUI extends ilTestServiceGUI
         require_once './Modules/Test/classes/class.ilTestScoring.php';
         $scorer = new ilTestScoring($this->object);
         $scorer->setPreserveManualScores(true);
-        $scorer->recalculateSolutions();
+        $scorer->recalculateSolution($activeId, $pass);
 
         if ($this->object->getAnonymity() == 0) {
             $user_name = ilObjUser::_lookupName(ilObjTestAccess::_getParticipantId($activeId));


### PR DESCRIPTION
Currently when you are manually scoring a user in a test currently the system goes through every other user's tests (and all of their passes of the test) and also manually rescores them even though nothing has changed.

This uses the singular function as intended.