### PR TITLE
calling iconv in sort_func only when value is string

### DIFF
--- a/Services/Utilities/classes/class.ilArrayUtil.php
+++ b/Services/Utilities/classes/class.ilArrayUtil.php
@@ -140,8 +140,13 @@ class ilArrayUtil
         }
 
         // JKN PATCH START
-        $leftValue = isset($left[$array_sortby]) ? iconv('UTF-8', 'ASCII//TRANSLIT', $left[$array_sortby]) : '';
-        $rightValue = isset($right[$array_sortby]) ? iconv('UTF-8', 'ASCII//TRANSLIT', $right[$array_sortby]) : '';
+        $leftValue = isset($left[$array_sortby]) && is_string($left[$array_sortby])
+            ? iconv('UTF-8', 'ASCII//TRANSLIT', $left[$array_sortby])
+            : '';
+
+        $rightValue = isset($right[$array_sortby]) && is_string($right[$array_sortby])
+            ? iconv('UTF-8', 'ASCII//TRANSLIT', $right[$array_sortby])
+            : '';
         // JKN PATCH END
 
         // this comparison should give optimal results if


### PR DESCRIPTION
Fix for taiga ticket https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2024-march-2025/issue/448.

Sorting a table by a column that contained an array of values resulted in an error. Now only calling iconv method if the value is a string.