### PR TITLE
Adds the ability back to mark groups complete

### DIFF
--- a/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
+++ b/Services/Tracking/classes/class.ilLearningProgressBaseGUI.php
@@ -745,21 +745,19 @@ class ilLearningProgressBaseGUI
         $comm->setValue($marks->getComment());
         $form->addItem($comm);
 
-        // JKN PATCH START
-        // if ($lp_mode == ilLPObjSettings::LP_MODE_MANUAL ||
-        //     $lp_mode == ilLPObjSettings::LP_MODE_MANUAL_BY_TUTOR) {
-        //     $completed = ilLPStatus::_lookupStatus($a_obj_id, $a_user_id);
+        if ($lp_mode == ilLPObjSettings::LP_MODE_MANUAL ||
+            $lp_mode == ilLPObjSettings::LP_MODE_MANUAL_BY_TUTOR) {
+            $completed = ilLPStatus::_lookupStatus($a_obj_id, $a_user_id);
 
-        //     $status = new ilCheckboxInputGUI(
-        //         $this->lng->txt('trac_completed'),
-        //         "completed"
-        //     );
-        //     $status->setChecked(
-        //         ($completed == ilLPStatus::LP_STATUS_COMPLETED_NUM)
-        //     );
-        //     $form->addItem($status);
-        // }
-        // JKN PATCH END
+            $status = new ilCheckboxInputGUI(
+                $this->lng->txt('trac_completed'),
+                "completed"
+            );
+            $status->setChecked(
+                ($completed == ilLPStatus::LP_STATUS_COMPLETED_NUM)
+            );
+            $form->addItem($status);
+        }
 
         $form->addCommandButton("updateUser", $this->lng->txt('save'));
 
@@ -796,25 +794,23 @@ class ilLearningProgressBaseGUI
             $marks->setMark($form->getInput("mark"));
             $marks->setComment($form->getInput("comment"));
 
-            // JKN PATCH START
+            $do_lp = false;
 
-            // $do_lp = false;
-
-            // // status/completed is optional
-            // $status = $form->getItemByPostVar("completed");
-            // if (is_object($status)) {
-            //     if ($marks->getCompleted() != $form->getInput("completed")) {
-            //         $marks->setCompleted($form->getInput("completed"));
-            //         $do_lp = true;
-            //     }
-            // }
+            // status/completed is optional
+            $status = $form->getItemByPostVar("completed");
+            if (is_object($status)) {
+                if ($marks->getCompleted() != $form->getInput("completed")) {
+                    $marks->setCompleted($form->getInput("completed"));
+                    $do_lp = true;
+                }
+            }
 
             $marks->update();
 
-            // // #11600
-            // if ($do_lp) {
-            //     ilLPStatusWrapper::_updateStatus($obj_id, $user_id);
-            // }
+            // #11600
+            if ($do_lp) {
+                ilLPStatusWrapper::_updateStatus($obj_id, $user_id);
+            }
         }
     }
 


### PR DESCRIPTION
### **NOTE**
I should have just combined this with the previous PR to add in functionality to Pass / Fail / inProgress Functionality to Manual By Tutor. 

### **Original Context:**

So I know this commit literally just undoes a bunch of patches we've done in the past, but i'll give some history etc.

So we removed the ability to mark users complete via the "Edit Details" page when we implemented the ability to mark users complete from the Learning Progress page in a dropdown, as we didn't want it confusing anyone to have two areas where you could mark users complete.

That really went out the window when we introduced the CompletionFibber plugin, as it introduced a second way to mark users complete anyways.

This also had the secondary effect of completely removing the ability to mark a user in a group complete if the learning progress status was set to "Tutors Monitor and Set Status".

Undoing this patch allows us to do this again.

![image](https://github.com/user-attachments/assets/fa5d7be7-2276-4074-813d-e86b635d6b77)

It's just about adding that "completed" checkbox back.

If you're testing this and notice that it still exists when LP status is set to other items (Collection etc.) but doesn't work, this is how the stock LMS works and i'm going to reccomend that we just let that happen as people should never be going into here to manually complete users if it is set to those. (using the CompletionFibber plugin to do that is the most common way.)

This came from an email with items I am scoping for Tom,

"To add to my last email…. In-fact, there is no way to mark a user completed within a group, even under the Learning Progress tab. The options for Turtor monitors and set status and determined by a collection of items; but no option to change the actual LP anywhere when set to “Tutors monitor and set status”

This is an issue where a course doesn’t have any eLearning associated with it, where we may only be tracking attendance. Example: Coach Course: [https://hps.lms.cpkn.ca/goto.php?target=crs_18198&client_id=hps]"

To test this, make a group with LP status set to "Tutors monitor and set status" and go to the Learning Progress tab and hit "Edit" beside a user's name, check the "Completed" and hit save.