### PR TITLE
Course reference copy was never adding ut_lp_settings in table

### DIFF
--- a/Modules/CourseReference/classes/class.ilObjCourseReference.php
+++ b/Modules/CourseReference/classes/class.ilObjCourseReference.php
@@ -157,9 +157,22 @@ class ilObjCourseReference extends ilContainerReference
      */
     public function cloneObject(int $a_target_id, int $a_copy_id = 0, bool $a_omit_tree = false): ?ilObject
     {
+        global $DIC;
+        $ilLog = $DIC["ilLog"];
+        $ilLog->write("ilObjCourseReference::cloneObject(), start");
+
         $new_obj = parent::cloneObject($a_target_id, $a_copy_id, $a_omit_tree);
         $new_obj->enableMemberUpdate($this->isMemberUpdateEnabled());
         $new_obj->update();
+        $newID = $new_obj->getId();
+
+        $id = $this->getId();
+        $ilLog->write("ilObjCourseReference::cloneObject(), Copying id settings:");
+        $ilLog->write($id);
+
+        $obj_settings = new ilLPObjSettings($id);
+        $obj_settings->cloneSettings($newID);
+        $ilLog->write("ilObjCourseReference::cloneObject(), Finishing.");
         return $new_obj;
     }
 }


### PR DESCRIPTION
There was a core issue with the LP from course references never getting created in ut_lp_settings table on clone.

https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2024-march-2025/issue/847

