### PR TITLE
Adds a check for safari to use sendBeacon instead of ajax on page unload

### DIFF
--- a/Modules/Scorm2004/scripts/buildrte/rte-min.js
+++ b/Modules/Scorm2004/scripts/buildrte/rte-min.js
@@ -1,4 +1,4 @@
-// Build: 2023416234957 
+// Build: 2025507160453 
 /*
  +-----------------------------------------------------------------------------+
  | ILIAS open source |
@@ -10647,6 +10647,10 @@ function sendAndLoad(url, data, callback, user, password, headers)
 function sendJSONRequest (url, data, callback, user, password, headers)
 {
  function unloadChrome() {
+ //CPKN Patch for Safari page unload in Courses.
+ if (navigator.userAgent.indexOf("Safari") > -1) {
+ return true;
+ }
  if (navigator.userAgent.indexOf("Chrom") > -1) {
  if (
  (

--- a/Modules/Scorm2004/scripts/buildrte/rte.js
+++ b/Modules/Scorm2004/scripts/buildrte/rte.js
@@ -1,4 +1,4 @@
-// Build: 2023416234957 
+// Build: 2025507160453 
 /*
 	+-----------------------------------------------------------------------------+
 	| ILIAS open source                                                           |
@@ -12140,6 +12140,12 @@ function sendAndLoad(url, data, callback, user, password, headers)
 function sendJSONRequest (url, data, callback, user, password, headers) 
 {
 	function unloadChrome() {
+
+		//CPKN Patch for Safari page unload in Courses.
+		if (navigator.userAgent.indexOf("Safari") > -1) {
+			return true;
+		}
+		
 		if (navigator.userAgent.indexOf("Chrom") > -1) {
 			if (
                    (

--- a/Modules/Scorm2004/scripts/rtemain/main.js
+++ b/Modules/Scorm2004/scripts/rtemain/main.js
@@ -1355,6 +1355,12 @@ function sendAndLoad(url, data, callback, user, password, headers)
 function sendJSONRequest (url, data, callback, user, password, headers) 
 {
 	function unloadChrome() {
+
+		//CPKN Patch for Safari page unload in Courses.
+		if (navigator.userAgent.indexOf("Safari") > -1) {
+			return true;
+		}
+		
 		if (navigator.userAgent.indexOf("Chrom") > -1) {
 			if (
                    (

--- a/Modules/ScormAicc/scripts/basisAPI.js
+++ b/Modules/ScormAicc/scripts/basisAPI.js
@@ -92,6 +92,12 @@ function sendRequest (url, data, callback, user, password, headers) {
                 return true;
             }
 		}
+
+		//CPKN Patch for Safari page unload in Courses.
+		if (navigator.userAgent.indexOf("Safari") > -1) {
+			return true;
+		}
+		
 		return false;
 	}
 


### PR DESCRIPTION
Essentially in both the Scorm2004/1.2 setups, on page unload in Chrome, there was an issue that the Chrome browser doesn't let you send ajax on page unload, they opt for using sendBeacon instead (for sending users progress and status on page unload)

Safari does the same thing, but it wasn't accounted for.

I think all this code was before sendBeacon was readily available for browsers, which is no longer the case.
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon

realistically it'd be safe to just get rid of all this logic and force it to use sendBeacon everytime, but looking not to break stuff.

the rte items are built using buildRTE.php in /var/www/ilias/demo/Modules/Scorm2004/classes, but this is already built so it should just be a merge and pull.