### PR TITLE
Allows sessions to be added to item groups now

### DIFF
--- a/Modules/ItemGroup/classes/class.ilItemGroupItems.php
+++ b/Modules/ItemGroup/classes/class.ilItemGroupItems.php
@@ -145,10 +145,10 @@ class ilItemGroupItems
         $nodes = $this->tree->getChilds($parent_node["child"]);
 
         foreach ($nodes as $node) {
-            // filter side blocks and session, item groups and role folder
+            // filter side blocks and item groups and role folder
             if ($node['child'] == $parent_node["child"] ||
                 $this->obj_def->isSideBlock($node['type']) ||
-                in_array($node['type'], array('sess', 'itgr', 'rolf', 'adm'))) {
+                in_array($node['type'], array('itgr', 'rolf', 'adm'))) {
                 continue;
             }
 


### PR DESCRIPTION
Allows sessions to be added to item groups now, tested pretty extensively and I can't find any negatives to allowing them. A course will have to be set to 'simplified view' vs 'sessions view' for this to work as intended.

https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2024-march-2025/issue/1510