### PR TITLE
fixes problem with importing of non master lang content pages

### DIFF
--- a/Services/COPage/classes/class.ilCOPageImporter.php
+++ b/Services/COPage/classes/class.ilCOPageImporter.php
@@ -102,7 +102,7 @@ class ilCOPageImporter extends ilXmlImporter
                             $page->updateFromXML();
                             $this->extractPluginProperties($page);
                         } else {
-                            if (ilPageObject::_exists($id[0], (int) $id[1], "-", true)) {
+                            if ($lstr === "-" && ilPageObject::_exists($id[0], (int) $id[1], "-", true)) {
                                 return;
                             }
                             $new_page = ilPageObjectFactory::getInstance($id[0]);
@@ -174,8 +174,7 @@ class ilCOPageImporter extends ilXmlImporter
 
     public function afterContainerImportProcessing(
         ilImportMapping $a_mapping
-    ): void {
-    }
+    ): void {}
 
     /**
      * Extract the properties of the plugged page contents


### PR DESCRIPTION
When importing a new course, only the master language content page was being imported. 