### PR TITLE
Adds mjs as a servable mimetype in ilias

### DIFF
--- a/src/FileUpload/mime_type_map.php
+++ b/src/FileUpload/mime_type_map.php
@@ -340,6 +340,13 @@ return [
         ILIAS\FileUpload\MimeType::TEXT__JAVASCRIPT,
         ILIAS\FileUpload\MimeType::TEXT__ECMASCRIPT,
     ],
+    'mjs' => [
+        ILIAS\FileUpload\MimeType::APPLICATION__JAVASCRIPT,
+        ILIAS\FileUpload\MimeType::APPLICATION__X_JAVASCRIPT,
+        ILIAS\FileUpload\MimeType::APPLICATION__ECMASCRIPT,
+        ILIAS\FileUpload\MimeType::TEXT__JAVASCRIPT,
+        ILIAS\FileUpload\MimeType::TEXT__ECMASCRIPT,
+    ],
     'json' => [
         ILIAS\FileUpload\MimeType::APPLICATION__JSON, // rfc4627
         ILIAS\FileUpload\MimeType::APPLICATION__JAVASCRIPT,


### PR DESCRIPTION
returns javascript for the mimetype for MJS, otherwise it will always return as text/plain and be unrenderable.
