### PR TITLE
Adds Certificate Translation Hotfix to the LMS wherein course titles …

### DIFF
--- a/Services/Certificate/classes/Placeholder/Values/class.ilCoursePlaceholderValues.php
+++ b/Services/Certificate/classes/Placeholder/Values/class.ilCoursePlaceholderValues.php
@@ -137,7 +137,20 @@ class ilCoursePlaceholderValues implements ilCertificatePlaceholderValues
             $placeholders['DATETIME_COMPLETED'] = $this->dateHelper->formatDateTime($completionDate);
         }
 
-        $placeholders['COURSE_TITLE'] = $this->ilUtilHelper->prepareFormOutput($courseObject->getTitle());
+        $lng_code = ilObjUser::_lookupLanguage($userId);
+        $course_translation = $courseObject->getObjectTranslation();
+        $title = $courseObject->getTitle();
+        if ($course_translation instanceof ilObjectTranslation) {
+            $languages = $course_translation->getLanguages();
+            foreach ($languages as $trans) {
+                if ($trans->getLanguageCode() === $lng_code) {
+                    $title = $trans->getTitle();
+                    break;
+                }
+            }
+        }
+
+        $placeholders['COURSE_TITLE'] = ilLegacyFormElementsUtil::prepareFormOutput($title);
 
         return $placeholders;
     }

--- a/Services/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
+++ b/Services/Certificate/classes/Placeholder/Values/class.ilDefaultPlaceholderValues.php
@@ -34,6 +34,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
     private ilCertificateUtilHelper $utilHelper;
     private ilUserDefinedFieldsPlaceholderValues $userDefinedFieldsPlaceholderValues;
     private int $birthdayDateFormat;
+    private ?ilLanguage $user_language = null;
 
     public function __construct(
         ?ilCertificateObjectHelper $objectHelper = null,
@@ -118,6 +119,8 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
             throw new ilException('The entered id: ' . $userId . ' is not an user object');
         }
 
+        $user_lng = $this->getUserLanguage($user);
+
         $placeholder = $this->placeholder;
 
         $placeholder['USER_LOGIN'] = $this->utilHelper->prepareFormOutput((trim($user->getLogin())));
@@ -129,7 +132,7 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
         $salutation = '';
         $gender = $user->getGender();
         if (trim($gender) !== '' && strtolower($gender) !== 'n') {
-            $salutation = $this->utilHelper->prepareFormOutput($this->language->txt("salutation_" . trim($gender)));
+            $salutation = $this->utilHelper->prepareFormOutput($user_lng->txt("salutation_" . trim($gender)));
         }
 
         $placeholder['USER_SALUTATION'] = $salutation;
@@ -161,6 +164,25 @@ class ilDefaultPlaceholderValues implements ilCertificatePlaceholderValues
             $placeholder,
             $this->userDefinedFieldsPlaceholderValues->getPlaceholderValues($userId, $objId)
         );
+    }
+
+    private function getUserLanguage(ilObjUser $user): ilLanguage
+    {
+        if ($this->user_language instanceof ilLanguage) {
+            return $this->user_language;
+        }
+        $language = new ilLanguage($user->getLanguage());
+        $language->loadLanguageModule('certificate');
+        $this->user_language = $language;
+        return $language;
+    }
+
+    /**
+     * @internal
+     */
+    public function setUserLanguage(ilLanguage $language): void
+    {
+        $this->user_language = $language;
     }
 
     /**

--- a/Services/Certificate/test/ilCertificateBaseTestCase.php
+++ b/Services/Certificate/test/ilCertificateBaseTestCase.php
@@ -26,4 +26,31 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class ilCertificateBaseTestCase extends TestCase
 {
+
+    protected function setUp(): void
+    {
+        if (!defined('ANONYMOUS_USER_ID')) {
+            define('ANONYMOUS_USER_ID', 13);
+        }
+
+        global $DIC;
+
+        $this->dic = is_object($DIC) ? clone $DIC : $DIC;
+
+        $DIC = new Container();
+
+        parent::setUp();
+    }
+
+    protected function setGlobalVariable(string $name, $value): void
+    {
+        global $DIC;
+
+        $GLOBALS[$name] = $value;
+
+        unset($DIC[$name]);
+        $DIC[$name] = static function (Container $c) use ($name) {
+            return $GLOBALS[$name];
+        };
+    }
 }

--- a/Services/Certificate/test/ilCoursePlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilCoursePlaceholderValuesTest.php
@@ -46,12 +46,33 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $language->method('txt')
             ->willReturn('Something');
 
-        $objectMock = $this->getMockBuilder(ilObject::class)
+        $objectMock = $this->getMockBuilder(ilObjCourse::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $objectMock->method('getTitle')
             ->willReturn('Some Title');
+
+        $obj_translation = $this->getMockBuilder(ilObjectTranslation::class)
+                                ->disableOriginalConstructor()
+                                ->getMock();
+
+        $german = $this->createMock(ilObjectTranslationLanguage::class);
+        $german->method('getLanguageCode')
+               ->willReturn('de');
+
+        $english = $this->createMock(ilObjectTranslationLanguage::class);
+        $english->method('getLanguageCode')
+                ->willReturn('en');
+
+        $obj_translation->method('getLanguages')
+                        ->willReturn([
+                            $german,
+                            $english
+                        ]);
+
+        $objectMock->method('getObjectTranslation')
+                   ->willReturn($obj_translation);
 
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
@@ -66,6 +87,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->willReturn('2018-09-10');
 
         $ilUtilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $ilUtilHelper->method('prepareFormOutput')
@@ -80,6 +102,12 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $ilDateHelper->method('formatDateTime')
             ->willReturn('2018-09-10 10:32:00');
 
+        $database = $this->getMockBuilder(ilDBInterface::class)
+                         ->getMock();
+
+        $this->setGlobalVariable('ilDB', $database);
+        $this->setGlobalVariable('lng', $language);
+
         $valuesObject = new ilCoursePlaceholderValues(
             $customUserFieldsPlaceholderValues,
             $defaultPlaceholderValues,
@@ -87,7 +115,7 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             $objectHelper,
             $participantsHelper,
             $ilUtilHelper,
-            $ilDateHelper
+            $ilDateHelper,
         );
 
         $placeholderValues = $valuesObject->getPlaceholderValues(100, 200);
@@ -135,12 +163,33 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
         $language->method('txt')
             ->willReturn('Something');
 
-        $objectMock = $this->getMockBuilder(ilObject::class)
+        $objectMock = $this->getMockBuilder(ilObjCourse::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $objectMock->method('getTitle')
             ->willReturn('SomeTitle');
+
+        $obj_translation = $this->getMockBuilder(ilObjectTranslation::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $german = $this->createMock(ilObjectTranslationLanguage::class);
+        $german->method('getLanguageCode')
+            ->willReturn('de');
+
+        $english = $this->createMock(ilObjectTranslationLanguage::class);
+        $english->method('getLanguageCode')
+            ->willReturn('en');
+
+        $obj_translation->method('getLanguages')
+            ->willReturn([
+                $german,
+                $english
+            ]);
+
+        $objectMock->method('getObjectTranslation')
+            ->willReturn($obj_translation);
 
         $objectHelper = $this->getMockBuilder(ilCertificateObjectHelper::class)
             ->getMock();
@@ -152,12 +201,19 @@ class ilCoursePlaceholderValuesTest extends ilCertificateBaseTestCase
             ->getMock();
 
         $utilHelper = $this->getMockBuilder(ilCertificateUtilHelper::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $utilHelper->method('prepareFormOutput')
             ->willReturnCallback(function ($input) {
                 return $input;
             });
+
+        $database = $this->getMockBuilder(ilDBInterface::class)
+            ->getMock();
+
+        $this->setGlobalVariable('ilDB', $database);
+        $this->setGlobalVariable('lng', $language);
 
         $valuesObject = new ilCoursePlaceholderValues(
             $customUserFieldsPlaceholderValues,

--- a/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
+++ b/Services/Certificate/test/ilDefaultPlaceholderValuesTest.php
@@ -157,6 +157,8 @@ class ilDefaultPlaceholderValuesTest extends ilCertificateBaseTestCase
             1
         );
 
+        $placeHolderObject->setUserLanguage($language);
+        
         $result = $placeHolderObject->getPlaceholderValues(100, 200);
 
         $this->assertEquals(


### PR DESCRIPTION
Tested this pretty extensively on demo, essentially when generating a persistent cert for users, the user's lang wasn't being taken into account for the course titles. Most of this work was taken from https://github.com/ILIAS-eLearning/ILIAS/pull/7435/files and I fixed a few of their bugs.