### PR TITLE
avoid blocking request when launching async worker

### DIFF
--- a/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
+++ b/src/BackgroundTasks/Implementation/TaskManager/AsyncTaskManager.php
@@ -44,7 +44,7 @@ class AsyncTaskManager extends BasicTaskManager
 
         // Call SOAP-Server
         $soap_client = new \ilSoapClient();
-        $soap_client->setResponseTimeout(0);
+        $soap_client->setResponseTimeout(1);
         $soap_client->enableWSDL(true);
         $soap_client->init();
         $session_id = session_id();


### PR DESCRIPTION
Fixes background task launching so the original web request can return before async work begins.

Previously, AsyncTaskManager::run() blocked on a SOAP self-call that executed runAsync() inline in the worker request, delaying redirects and making long-running tasks appear synchronous.