### PR TITLE
use getSubPathname() instead of realpath-based substr in unzip copy loop

### DIFF
--- a/Services/FileServices/classes/class.ilFileUtils.php
+++ b/Services/FileServices/classes/class.ilFileUtils.php
@@ -966,10 +966,8 @@ class ilFileUtils
                 ),
                 RecursiveIteratorIterator::SELF_FIRST
             );
-            $tmp_real = realpath($temporary_unzip_directory);
             foreach ($it as $item) {
-                $rel = substr($item->getPathname(), strlen($tmp_real));
-                $dest = $target_directory . $rel;
+                $dest = $target_directory . DIRECTORY_SEPARATOR . $it->getSubPathname();
                 if ($item->isDir()) {
                     if (!is_dir($dest)) {
                         mkdir($dest, 0755, true);


### PR DESCRIPTION
Using realpath() to strip the temp dir prefix from getPathname() breaks when symlinks are in the path.
