### PR TITLE
fix to scorm2004 status update issue

### DIFF
--- a/Modules/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
+++ b/Modules/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Ports ilScorm2004DatabaseUpdateSteps::step_1 through step_5 from later, upstream
+ * ILIAS versions (this component has no Setup/DatabaseUpdateSteps class yet on our
+ * release_8 base, so none of these have run here before).
+ *
+ * step_1-3 widen cmi_interaction.c_timestamp/id and cmi_correct_response.pattern.
+ * All three were originally sized for short, machine-generated SCORM identifiers,
+ * but real-world content (e.g. multi-select "select all that apply" interactions,
+ * whose correct-response pattern concatenates every correct choice with "[,]") can
+ * legitimately exceed the old limits. When that happens the insert throws an
+ * uncaught SQLSTATE[22001] "Data too long for column" error, which - since
+ * ilSCORM2004StoreData::setCMIData() runs outside any transaction and isn't
+ * wrapped in a try/catch - aborts the whole commit after cmi_node has already been
+ * saved, leaving sahs_user/ut_lp_marks stuck without ever reaching the status sync.
+ * This is the fix for the "correct_response.pattern too long" bug found while
+ * testing the null-now_global_status fix on course ref_id 322.
+ *
+ * step_4 widens cp_dependency.resourceid for the same reason (same class of bug,
+ * not yet observed here, but the column is equally undersized).
+ *
+ * step_5 adds a standalone index on sahs_user.user_id - the table's primary key is
+ * the composite (obj_id, user_id), which can't be used efficiently for queries that
+ * filter by user_id alone across objects; a performance fix, not a correctness one.
+ */
+class ilScorm2004DatabaseUpdateSteps implements ilDatabaseUpdateSteps
+{
+    protected ilDBInterface $db;
+
+    public function prepare(ilDBInterface $db): void
+    {
+        $this->db = $db;
+    }
+
+    public function step_1(): void
+    {
+        $this->db->modifyTableColumn("cmi_interaction", "c_timestamp", array("type" => "text", "length" => 40, "notnull" => false, 'default' => null));
+    }
+
+    public function step_2(): void
+    {
+        $this->db->modifyTableColumn("cmi_correct_response", "pattern", array("type" => "text", "length" => 4000, "notnull" => false, 'default' => null));
+    }
+
+    public function step_3(): void
+    {
+        $this->db->modifyTableColumn("cmi_interaction", "id", array("type" => "text", "length" => 4000, "notnull" => false, 'default' => null));
+    }
+
+    public function step_4(): void
+    {
+        $this->db->modifyTableColumn("cp_dependency", "resourceid", array("type" => "text", "length" => 200, "notnull" => false, 'default' => null));
+    }
+
+    public function step_5(): void
+    {
+        if (!$this->db->indexExistsByFields('sahs_user', ['user_id'])) {
+            $this->db->addIndex('sahs_user', ['user_id'], 'i1');
+        }
+    }
+}

--- a/Modules/Scorm2004/classes/Setup/class.ilScorm2004SetupAgent.php
+++ b/Modules/Scorm2004/classes/Setup/class.ilScorm2004SetupAgent.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+use ILIAS\Setup;
+use ILIAS\Refinery;
+use ILIAS\UI;
+
+class ilScorm2004SetupAgent implements Setup\Agent
+{
+    use Setup\Agent\HasNoNamedObjective;
+
+    public function hasConfig(): bool
+    {
+        return false;
+    }
+
+    public function getArrayToConfigTransformation(): Refinery\Transformation
+    {
+        throw new LogicException("Agent has no config.");
+    }
+
+    public function getInstallObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getUpdateObjective(Setup\Config $config = null): Setup\Objective
+    {
+        return new ilDatabaseUpdateStepsExecutedObjective(
+            new ilScorm2004DatabaseUpdateSteps()
+        );
+    }
+
+    public function getBuildArtifactObjective(): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    public function getStatusObjective(Setup\Metrics\Storage $storage): Setup\Objective
+    {
+        return new Setup\Objective\NullObjective();
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getMigrations(): array
+    {
+        return [];
+    }
+}

--- a/Modules/Scorm2004/classes/class.ilSCORM2004StoreData.php
+++ b/Modules/Scorm2004/classes/class.ilSCORM2004StoreData.php
@@ -164,7 +164,13 @@ class ilSCORM2004StoreData
 
         //$new_global_status=ilSCORM2004StoreData::setGlobalObjectivesAndGetGlobalStatus($userId, $packageId, $data);
         ilSCORM2004StoreData::setGlobalObjectives($userId, $packageId, $data);
-        $new_global_status = $data->now_global_status;
+        // $data->now_global_status is client-supplied and may legitimately be null/absent
+        // (e.g. when syncing from the SCORM Offline Player, or if the tab closed before the
+        // client-side status computation finished) - normalize defensively instead of trusting it blindly.
+        $new_global_status = $data->now_global_status ?? null;
+        if ($new_global_status !== null) {
+            $new_global_status = (int) $new_global_status;
+        }
         $return["new_global_status"] = $new_global_status;
 
         // mantis #30293
@@ -175,7 +181,11 @@ class ilSCORM2004StoreData
             }
         }
 
-        ilSCORM2004StoreData::syncGlobalStatus($userId, $packageId, $refId, $data, $new_global_status, $time_from_lms);
+        try {
+            ilSCORM2004StoreData::syncGlobalStatus($userId, $packageId, $refId, $data, $new_global_status, $time_from_lms);
+        } catch (\Throwable $e) {
+            $ilLog->error("SCORM2004 syncGlobalStatus failed for packageId=" . $packageId . ", userId=" . $userId . ": " . $e->getMessage() . "\n" . $e->getTraceAsString());
+        }
 
         $ilLog->debug("SCORM: return of persistCMIData: " . json_encode($return));
         if ($jsMode) {
@@ -655,29 +665,46 @@ class ilSCORM2004StoreData
         return $returnAr;
     }
 
-    public static function syncGlobalStatus(int $userId, int $packageId, int $refId, object $data, int $new_global_status, bool $time_from_lms): void
+    public static function syncGlobalStatus(int $userId, int $packageId, int $refId, object $data, ?int $new_global_status, bool $time_from_lms): void
     {
         global $DIC;
         $ilDB = $DIC->database();
-        $ilLog = $DIC["ilLog"];
+        $ilLog = ilLoggerFactory::getLogger('sc13');
         $saved_global_status = $data->saved_global_status;
         $ilLog->write("saved_global_status=" . $saved_global_status);
 
-        //update percentage_completed, sco_total_time_sec,status in sahs_user
+        if ($new_global_status === null) {
+            $ilLog->warning(
+                "SCORM2004 syncGlobalStatus: now_global_status missing/null in client payload for "
+                . "packageId=" . $packageId . ", userId=" . $userId . ", refId=" . $refId . ". "
+                . "Skipping sahs_user.status/ut_lp_marks update for this commit to avoid overwriting "
+                . "an existing valid status with an unknown value."
+            );
+        }
+
+        //update percentage_completed, sco_total_time_sec in sahs_user - status only if it can be trusted
         $totalTime = (int) $data->totalTimeCentisec;
         $totalTime = round($totalTime / 100);
-        $ilDB->queryF(
-            'UPDATE sahs_user SET sco_total_time_sec=%s, status=%s, percentage_completed=%s WHERE obj_id = %s AND user_id = %s',
-            array('integer', 'integer', 'integer', 'integer', 'integer'),
-            array($totalTime, $new_global_status, $data->percentageCompleted, $packageId, $userId)
-        );
+        if ($new_global_status !== null) {
+            $ilDB->queryF(
+                'UPDATE sahs_user SET sco_total_time_sec=%s, status=%s, percentage_completed=%s WHERE obj_id = %s AND user_id = %s',
+                array('integer', 'integer', 'integer', 'integer', 'integer'),
+                array($totalTime, $new_global_status, $data->percentageCompleted, $packageId, $userId)
+            );
+        } else {
+            $ilDB->queryF(
+                'UPDATE sahs_user SET sco_total_time_sec=%s, percentage_completed=%s WHERE obj_id = %s AND user_id = %s',
+                array('integer', 'integer', 'integer', 'integer'),
+                array($totalTime, $data->percentageCompleted, $packageId, $userId)
+            );
+        }
 
         self::ensureObjectDataCacheExistence();
 
         $ilObjDataCache = $DIC["ilObjDataCache"];
 
-        // update learning progress
-        if ($new_global_status != null) {//could only happen when synchronising from SCORM Offline Player
+        // update learning progress only when we actually have a trustworthy status value
+        if ($new_global_status !== null) {
             ilLPStatus::writeStatus($packageId, $userId, $new_global_status, (int) $data->percentageCompleted);
 
             //			here put code for soap to MaxCMS e.g. when if($saved_global_status != $new_global_status)

--- a/Modules/Scorm2004/test/ilSCORM2004StoreDataTest.php
+++ b/Modules/Scorm2004/test/ilSCORM2004StoreDataTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of ILIAS, a powerful learning management system
+ * published by ILIAS open source e-Learning e.V.
+ *
+ * ILIAS is licensed with the GPL-3.0,
+ * see https://www.gnu.org/licenses/gpl-3.0.en.html
+ * You should have received a copy of said license along with the
+ * source code, too.
+ *
+ * If this is not the case or you just want to try ILIAS, you'll find
+ * us at:
+ * https://www.ilias.de
+ * https://github.com/ILIAS-eLearning
+ *
+ *********************************************************************/
+
+/**
+ * Regression tests for the SCORM 2004 "null now_global_status" bug: syncGlobalStatus()
+ * used to require a non-nullable int $new_global_status, so a client payload with a
+ * missing/null now_global_status (e.g. from the SCORM Offline Player, or a tab closed
+ * right after Commit/Terminate) threw an uncaught TypeError under strict_types - after
+ * cmi_node had already been persisted, but before sahs_user/ut_lp_marks were touched.
+ *
+ * @author Uwe Kohnle <support@internetlehrer-gmbh.de>
+ */
+class ilSCORM2004StoreDataTest extends ilScorm2004BaseTestCase
+{
+    private const PACKAGE_ID = 42;
+    private const USER_ID = 6;
+    private const REF_ID = 99;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!defined('ILIAS_LOG_ENABLED')) {
+            define('ILIAS_LOG_ENABLED', false);
+        }
+        if (!defined('CLIENT_ID')) {
+            define('CLIENT_ID', 1);
+        }
+
+        $this->addGlobal_ilDB();
+        $this->addGlobal_ilObjDataCache();
+        $this->addGlobal_ilAppEventHandler();
+
+        // For a trustworthy status, syncGlobalStatus() calls ilLPStatus::writeStatus(),
+        // which resolves its logger via $DIC->logger()->trac() - backed by
+        // $DIC['ilLoggerFactory']. Stub it so that path doesn't fatal on a plain,
+        // unconfigured mock (calling ->debug() on null).
+        $componentLogger = $this->createMock(ilLogger::class);
+        $loggerFactory = $this->createMock(ilLoggerFactory::class);
+        $loggerFactory->method('getComponentLogger')->willReturn($componentLogger);
+        $this->setGlobalVariable('ilLoggerFactory', $loggerFactory);
+    }
+
+    private function buildData(): stdClass
+    {
+        $data = new stdClass();
+        $data->saved_global_status = 'incomplete';
+        $data->totalTimeCentisec = 12345;
+        $data->percentageCompleted = 0;
+        return $data;
+    }
+
+    public function test_syncGlobalStatus_nullStatus_doesNotThrowAndSkipsStatusColumn(): void
+    {
+        $data = $this->buildData();
+
+        /** @var ilDBInterface&PHPUnit\Framework\MockObject\MockObject $ilDB */
+        $ilDB = $GLOBALS['DIC']['ilDB'];
+        $ilDB->expects($this->once())
+            ->method('queryF')
+            ->with(
+                $this->stringContains('UPDATE sahs_user SET sco_total_time_sec=%s, percentage_completed=%s'),
+                array('integer', 'integer', 'integer', 'integer'),
+                array(123, 0, self::PACKAGE_ID, self::USER_ID)
+            );
+        // no trustworthy status -> ilLPStatus::writeStatus() (and its ut_lp_marks upsert)
+        // must never be reached
+        $ilDB->expects($this->never())->method('replace');
+
+        ilSCORM2004StoreData::syncGlobalStatus(
+            self::USER_ID,
+            self::PACKAGE_ID,
+            self::REF_ID,
+            $data,
+            null,
+            true
+        );
+    }
+
+    public function test_syncGlobalStatus_validStatus_updatesStatusColumnAndWritesLearningProgress(): void
+    {
+        $data = $this->buildData();
+
+        /** @var ilDBInterface&PHPUnit\Framework\MockObject\MockObject $ilDB */
+        $ilDB = $GLOBALS['DIC']['ilDB'];
+        $ilDB->expects($this->once())
+            ->method('queryF')
+            ->with(
+                $this->stringContains('UPDATE sahs_user SET sco_total_time_sec=%s, status=%s, percentage_completed=%s'),
+                array('integer', 'integer', 'integer', 'integer', 'integer'),
+                array(123, ilLPStatus::LP_STATUS_COMPLETED_NUM, 0, self::PACKAGE_ID, self::USER_ID)
+            );
+        // ilLPStatus::writeStatus() takes the insert path (no existing ut_lp_marks row in
+        // the mock) - its replace() call into ut_lp_marks is our proxy for "learning
+        // progress was actually written", since writeStatus() isn't independently mockable
+        $ilDB->expects($this->atLeastOnce())->method('replace');
+
+        ilSCORM2004StoreData::syncGlobalStatus(
+            self::USER_ID,
+            self::PACKAGE_ID,
+            self::REF_ID,
+            $data,
+            ilLPStatus::LP_STATUS_COMPLETED_NUM,
+            true
+        );
+    }
+
+    public function test_syncGlobalStatus_notAttemptedStatusZero_isNotTreatedAsNull(): void
+    {
+        $data = $this->buildData();
+
+        /** @var ilDBInterface&PHPUnit\Framework\MockObject\MockObject $ilDB */
+        $ilDB = $GLOBALS['DIC']['ilDB'];
+        $ilDB->expects($this->once())
+            ->method('queryF')
+            ->with(
+                $this->stringContains('UPDATE sahs_user SET sco_total_time_sec=%s, status=%s, percentage_completed=%s'),
+                array('integer', 'integer', 'integer', 'integer', 'integer'),
+                array(123, ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM, 0, self::PACKAGE_ID, self::USER_ID)
+            );
+        // under the old `!= null` check, an int 0 status would have been loosely-equal to
+        // null and incorrectly skipped ilLPStatus::writeStatus() entirely
+        $ilDB->expects($this->atLeastOnce())->method('replace');
+
+        ilSCORM2004StoreData::syncGlobalStatus(
+            self::USER_ID,
+            self::PACKAGE_ID,
+            self::REF_ID,
+            $data,
+            ilLPStatus::LP_STATUS_NOT_ATTEMPTED_NUM,
+            true
+        );
+    }
+}


### PR DESCRIPTION
If SCORM2004 has a huge interaction cmi_interaction it would cause a db error that would be suppressed and sometimes not save the right status. This does the following:

1. Cleans up the SCORM2004 class to actually handle errors
2. Takes DB Updates from Ilias 11 to handle large interaction payload https://github.com/ILIAS-eLearning/ILIAS/blob/57261f5ce2fe00acca10545f0359dd1d50607144/components/ILIAS/Scorm2004/classes/Setup/class.ilScorm2004DatabaseUpdateSteps.php#L49

php setup/cli.php update -y